### PR TITLE
Enable qemu 64-bit support

### DIFF
--- a/meta-optee/recipes-core/arm-tf/arm-tf_git.bb
+++ b/meta-optee/recipes-core/arm-tf/arm-tf_git.bb
@@ -15,7 +15,20 @@ SRCREV_hikey-optee64 = "bdec62eeb8f3153a4647770e08aafd56a0bcd42b"
 SRC_URI_hikey-optee64 = "git://github.com/96boards-hikey/arm-trusted-firmware.git;branch=hikey"
 PV_hikey-optee64 = "1.1+git${SRCPV}"
 
-COMPATIBLE_MACHINE = "(fvp|hikey)-optee64"
+# Currently, we don't build the edk2 for this platform, but instead just use a
+# prebuilt snapshot.  Note that this seems to break out-of-tree
+# compilation, as the EXTERNALSRC seems to prevent it from downloading
+# the snapshot.
+SRCREV_qemu-optee64 = "b3a3dde456445d294d83b18faf2769f6aa14ab48"
+SRC_URI_qemu-optee64 = " \
+    git://github.com/linaro-swg/arm-trusted-firmware.git;branch=optee_v2.1.0_paged_armtf_v1.2 \
+    file://0001-workaround-for-macro-error.patch \
+    http://snapshots.linaro.org/components/kernel/leg-virt-tianocore-edk2-upstream/989/QEMU-KERNEL-AARCH64/RELEASE_GCC49/QEMU_EFI.fd;sha256sum=2da5b905a30c04bbf999975f844da123f40fe9d60ed276ca6e6c3b595e35b16c;md5sum=b3cee74b5b9fcd076772a7bd2e06ff27 \
+"
+PV_qemu-optee64 = "1.2+git${SRCPV}"
+DEPENDS_qemu-optee64 = "optee-os"
+
+COMPATIBLE_MACHINE = "(fvp|hikey|qemu)-optee64"
 
 ARMTF_ARGS_fvp-optee64 = " \
         BL32=${STAGING_DIR_HOST}/lib/firmware/tee.bin \
@@ -35,8 +48,21 @@ ARMTF_ARGS_hikey-optee64 = " \
         SPD=opteed \
 "
 
+ARMTF_ARGS_qemu-optee64 = " \
+        BL32=${STAGING_DIR_HOST}/lib/firmware/tee.bin \
+        BL33=${WORKDIR}/QEMU_EFI.fd \
+        ARM_TSP_RAM_LOCATION=tdram \
+        PLAT=qemu \
+        DEBUG=0 \
+        LOG_LEVEL=50 \
+        ERROR_DEPRECATED=1 \
+        BL32_RAM_LOCATION=tdram \
+        SPD=opteed \
+"
+
 ARMTF_PLAT_fvp-optee64 = "fvp"
 ARMTF_PLAT_hikey-optee64 = "hikey"
+ARMTF_PLAT_qemu-optee64 = "qemu"
 
 LIC_FILES_CHKSUM = " \
     file://license.md;md5=829bdeb34c1d9044f393d5a16c068371 \
@@ -68,6 +94,8 @@ do_install () {
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 644 ${S}/build/${ARMTF_PLAT}/release/bl1.bin ${DEPLOYDIR}
+    install -m 644 ${S}/build/${ARMTF_PLAT}/release/bl2.bin ${DEPLOYDIR}
+    install -m 644 ${S}/build/${ARMTF_PLAT}/release/bl31.bin ${DEPLOYDIR}
     install -m 644 ${S}/build/${ARMTF_PLAT}/release/fip.bin ${DEPLOYDIR}
 }
 

--- a/meta-optee/recipes-core/images/optee-image.bb
+++ b/meta-optee/recipes-core/images/optee-image.bb
@@ -8,6 +8,7 @@ LICENSE = "MIT"
 
 DEPENDS_fvp-optee64 = "arm-tf"
 DEPENDS_hikey-optee64 = "arm-tf"
+DEPENDS_qemu-optee64 = "arm-tf"
 
 # By default the image has quite a bit of stuff in it.  Uncomment
 # these few lines to only install the bare minimum, making a minimal

--- a/meta-optee/recipes-devtools/qemu/qemu_git.bb
+++ b/meta-optee/recipes-devtools/qemu/qemu_git.bb
@@ -11,9 +11,9 @@ DEPENDS = "glib-2.0 zlib pixman"
 inherit autotools
 BBCLASSEXTEND = "native nativesdk"
 
-SRCREV = "c7288767523f6510cf557707d3eb5e78e519b90d"
+SRCREV = "53279c76cf071fed07a336948d37c72e3613e0b7"
 SRC_URI = "git://github.com/qemu/qemu.git"
-PV = "2.5.0+git${SRCPV}"
+PV = "2.7.0+git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
                     file://COPYING.LIB;md5=79ffa0ec772fa86740948cb7327a0cc7 "
@@ -26,7 +26,7 @@ S = "${WORKDIR}/git/"
 
 do_configure () {
     (cd ${S}; git submodule update --init dtc)
-    ${S}/configure --target-list=arm-softmmu --extra-cflags="-Wno-error" \
+    ${S}/configure --target-list=arm-softmmu,aarch64-softmmu --extra-cflags="-Wno-error" \
         --prefix=${prefix} --sysconfdir=${sysconfdir} --libexecdir=${libexecdir} \
         --localstatedir=${localstatedir} \
 	--enable-fdt \

--- a/meta-optee/recipes-kernel/linux/linux-optee.inc
+++ b/meta-optee/recipes-kernel/linux/linux-optee.inc
@@ -12,6 +12,9 @@ def get_optee_configs(d):
     if machine == "qemu-optee32":
         return ("arch/arm/configs/vexpress_defconfig " +
             "{0}/qemu.conf").format(d.getVar("WORKDIR", True))
+    elif machine == "qemu-optee64":
+        return ("arch/arm64/configs/defconfig " +
+            "{0}/qemu.conf").format(d.getVar("WORKDIR", True))
     elif machine == "fvp-optee64":
         return ("arch/arm64/configs/defconfig " +
             "{0}/fvp.conf").format(d.getVar("WORKDIR", True))

--- a/meta-optee/recipes-kernel/linux/linux-optee_git.bb
+++ b/meta-optee/recipes-kernel/linux/linux-optee_git.bb
@@ -9,6 +9,7 @@ PV = "4.5+git${SRCPV}"
 SRC_URI = "git://github.com/linaro-swg/linux.git;branch=optee"
 
 SRC_URI_append_qemu-optee32   = " file://qemu.conf"
+SRC_URI_append_qemu-optee64   = " file://qemu.conf"
 SRC_URI_append_fvp-optee64    = " file://fvp.conf"
 SRC_URI_append_hikey-optee64 = " file://hikey.conf"
 SRC_URI_append_hikey-optee64 = " file://usb_net_dm9601.conf"

--- a/meta-optee/recipes-security/optee/optee-client_git.bb
+++ b/meta-optee/recipes-security/optee/optee-client_git.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
 "
 SRCREV = "17d1addc465a667f375837cdbe4fa7ebac08539b"
 PR = "r0"
-PV = "2.0.0+git${SRCPV}"
+PV = "2.1.0+git${SRCPV}"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
 S = "${WORKDIR}/git"

--- a/meta-optee/recipes-security/optee/optee-os_git.bb
+++ b/meta-optee/recipes-security/optee/optee-os_git.bb
@@ -30,6 +30,16 @@ python () {
              " ta-targets=ta_arm32").format(d.getVar("HOST_PREFIX", True)))
         d.setVar("OPTEE_SHORT_MACHINE", "vexpress")
         d.setVar("OPTEE_ARCH", "arm32")
+    elif machine == "qemu-optee64":
+        d.setVar("EXTRA_OEMAKE",
+            ("PLATFORM=vexpress-qemu_armv8a" +
+             " CFG_ARM64_core=y" +
+             " CFG_ARM32_core=n" +
+             " CROSS_COMPILE_core={0}" +
+             " CROSS_COMPILE_ta_arm64={0}" +
+             " ta-targets=ta_arm64").format(d.getVar("HOST_PREFIX", True)))
+        d.setVar("OPTEE_SHORT_MACHINE", "vexpress")
+        d.setVar("OPTEE_ARCH", "arm64")
     elif machine == "fvp-optee64":
         d.setVar("EXTRA_OEMAKE",
             ("V=1 PLATFORM=vexpress-fvp" +

--- a/meta-optee/recipes-security/optee/optee-os_git.bb
+++ b/meta-optee/recipes-security/optee/optee-os_git.bb
@@ -58,9 +58,9 @@ inherit deploy
 inherit pythonnative
 
 SRC_URI = "git://github.com/OP-TEE/optee_os.git"
-SRCREV = "ca6737b41c68973c6a0bb271906423c9e2d4e7db"
+SRCREV = "aca1545d0f545d32c2f384151d287a1bff6a6a20"
 PR = "r0"
-PV = "2.0.0+git${SRCPV}"
+PV = "2.1.0+git${SRCPV}"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
 
 S = "${WORKDIR}/git"

--- a/meta-optee/recipes-security/optee/optee-test_git.bb
+++ b/meta-optee/recipes-security/optee/optee-test_git.bb
@@ -11,9 +11,9 @@ DEPENDS = "optee-os optee-client"
 
 SRC_URI = "git://github.com/OP-TEE/optee_test.git \
 "
-SRCREV = "26b8aa8821e22df5606f62a85c20fc177b505a60"
+SRCREV = "1425f95af8fee6428fd88ec6d123bbdd46635454"
 PR = "r0"
-PV = "2.0.0+git${SRCPV}"
+PV = "2.1.0+git${SRCPV}"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 inherit pythonnative

--- a/run64.sh
+++ b/run64.sh
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+root=build-64/tmp-glibc/sysroots/x86_64-linux
+deploy=build-64/tmp-glibc/deploy/images/qemu-optee64
+
+# When running semihosting mode, we need access to all of the images
+# in one place.
+work=tmpqemu$$
+mkdir $work
+
+ln -sr ${deploy}/bl1.bin $work
+ln -sr ${deploy}/bl2.bin $work
+ln -sr ${deploy}/bl31.bin $work
+ln -sr ${deploy}/fip.bin $work
+ln -sr build-64/tmp-glibc/sysroots/qemu-optee64/lib/firmware/tee.bin $work/bl32.bin
+ln -sr build-64/downloads/QEMU_EFI.fd $work/bl33.bin
+
+cd $work
+
+# strace -f \
+../$root/usr/bin/qemu-system-aarch64 \
+	-nographic \
+	-machine virt,secure=on \
+	-cpu cortex-a57 \
+	-bios bl1.bin \
+	-semihosting \
+	-d unimp \
+	-serial tcp:localhost:54320 -serial tcp:localhost:54321 \
+	-m 1057 \
+	-netdev user,id=unet,hostfwd=tcp::5001-:22,hostfwd=tcp::2159-:2159 \
+	-device virtio-net-device,netdev=unet \
+	-device virtio-scsi-device,id=scsi \
+	-drive file=../${deploy}/optee-image-qemu-optee64.ext4,id=rootimg,if=none,format=raw \
+	-device scsi-hd,drive=rootimg \
+	-kernel ../${deploy}/Image \
+	--append "console=ttyAMA0,38400 keep_bootcon root=/dev/vda2" \
+	-initrd ../${deploy}/optee-image-qemu-optee64.cpio.gz
+
+cd ..
+rm -rf $work
+
+exit 0
+
+	-kernel /mnt/oe/oe-core/build/tmp-glibc/deploy/images/qemuarm/zImage-qemuarm.bin \
+	-net user \
+	-initrd tmp-glibc/deploy/images/qemuarm/optee-image-qemuarm.cpio.gz \
+	--append "console=ttyAMA0,1152000"
+	-net nic,model=virtio \
+	-net tap,vlan=0,ifname=tap0,script=no,downscript=no \
+
+	-netdev user,id=unet \
+	-device virtio-net-device,netdev=unet \
+	-show-cursor \
+	-serial mon:vc \
+	-usb -usbdevice wacom-tablet \
+
+	-drive file=/mnt/oe/oe-core/build/tmp-glibc/deploy/images/qemuarm/core-image-minimal-qemuarm-20160420193340.rootfs.ext4,if=virtio,format=raw \
+	--append "root=/dev/vda rw console=ttyAMA0,115200 console=ttyAMA0 ip=192.168.7.2::192.168.7.1:255.255.255.0 mem=128M highres=off rootfstype=ext4 "


### PR DESCRIPTION
Modeled after the qemu_v8 support in the optee_os build system. Instead of building edk2, grab a snapshot and include the binary directly.
